### PR TITLE
BUG: after editing the bookmarks, they does not reflect immediatly

### DIFF
--- a/src/components/homepage/bookmarks/folder/index.tsx
+++ b/src/components/homepage/bookmarks/folder/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/context-menu"
 
 import type { BookmarkFolderNode } from "@/types/bookmark-types"
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import folderIcon from "data-base64:@/assets/folder-svgrepo-com.svg"
 import DeleteDialog from "../delete-dialog"
 import { DeleteIcon, EditIcon, MoveIcon } from "lucide-react"
@@ -25,7 +25,7 @@ type Props = BookmarkFolderNode & {
 const BookmarkFolder = (props: Props) => {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [isUpdateDialogOpen, setIsUpdateDialogOpen] = useState(false)
-  const { icon, setIcon } = useIcon({ id: props.id, defaultIcon: folderIcon })
+  const { icon, setIcon, fetchIcon } = useIcon({ id: props.id, defaultIcon: folderIcon })
 
   const { isOver, setNodeRef } = useDroppable({
     id: props.id,
@@ -42,6 +42,12 @@ const BookmarkFolder = (props: Props) => {
     id: props.id,
     data: { index: props.index },
   })
+
+  useEffect(() => {
+    if (!isUpdateDialogOpen) {
+      fetchIcon()
+    }
+  }, [isUpdateDialogOpen, fetchIcon])
 
   const style = transform
     ? {

--- a/src/components/homepage/bookmarks/url/index.tsx
+++ b/src/components/homepage/bookmarks/url/index.tsx
@@ -2,7 +2,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { fetchFavicon } from "@/lib/fetch-favicon"
 import { useSettings } from "@/providers/settings-provider"
 import type { BookmarkUrlNode } from "@/types/bookmark-types"
-import React, { useCallback, useState } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 
 import {
   ContextMenu,
@@ -95,6 +95,13 @@ const BookmarkUrl = ({ disableContextMenu = false, ...props }: Props) => {
     }
   }, [props.url])
 
+  useEffect(() => {
+    setData((prevState) => ({
+      ...prevState,
+      title: props.title,
+    }))
+  }, [props.title])
+  
   const openInNewTab = useCallback((url: string) => {
     window.open(url, "_blank")
   }, [])

--- a/src/components/homepage/bookmarks/url/index.tsx
+++ b/src/components/homepage/bookmarks/url/index.tsx
@@ -31,7 +31,7 @@ const BookmarkUrl = ({ disableContextMenu = false, ...props }: Props) => {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false)
   const [editDialogOpen, setEditDialogOpen] = useState(false)
-  const { icon } = useIcon({ id: props.id, defaultIcon: "" })
+  const { icon, fetchIcon } = useIcon({ id: props.id, defaultIcon: "" })
 
   const {
     settings: { general },
@@ -101,6 +101,12 @@ const BookmarkUrl = ({ disableContextMenu = false, ...props }: Props) => {
       title: props.title,
     }))
   }, [props.title])
+  
+  useEffect(() => {
+    if (!editDialogOpen) {
+      fetchIcon()
+    }
+  }, [editDialogOpen, fetchIcon])
   
   const openInNewTab = useCallback((url: string) => {
     window.open(url, "_blank")

--- a/src/hooks/use-icon.ts
+++ b/src/hooks/use-icon.ts
@@ -10,16 +10,18 @@ type Props = {
 const useIcon = (props: Props) => {
   const [icon, setIcon] = useState(props.defaultIcon || "")
 
-  useAsyncEffect(async () => {
+  const fetchIcon = async () => {
     const key = `icon-${props.id}`
     const icon = await getIconFromLocalStorage<{ icon: string }>(key)
 
     if (icon?.[key]?.icon) {
       setIcon(icon[key].icon)
     }
-  }, [props.id])
+  }
 
-  return { icon, setIcon }
+  useAsyncEffect(fetchIcon, [props.id])
+
+  return { icon, setIcon, fetchIcon }
 }
 
 export default useIcon


### PR DESCRIPTION
Fix for issue https://github.com/jrTilak/vivid-tab/issues/13 (BUG: after editing the bookmarks, they does not reflect immediatly)

Added several useEffects to track any changes made to the bookmark title as well as the folder and URL icons, previously was updating title only when bookmark URL was updated. Also updated useIcon to allow icons to be refetched.