### PR TITLE
FEAT: Edit tabs

### DIFF
--- a/src/components/homepage/bookmarks/bookmarks.tsx
+++ b/src/components/homepage/bookmarks/bookmarks.tsx
@@ -35,6 +35,8 @@ import {
   ContextMenuShortcut,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
+import DeleteDialog from "./delete-dialog"
+import EditBookmarkTab from "./edit-bookmark-tab"
 
 const Bookmarks = () => {
   const [activeRootFolder, setActiveRootFolder] = useState("home")
@@ -59,6 +61,9 @@ const Bookmarks = () => {
   const [isCreateAFolderDialogOpen, setIsCreateAFolderDialogOpen] =
     useState(false)
   const [createFolderParentId, setCreateFolderParentId] = useState("")
+  const [editFolder, setEditFolder] = useState<BookmarkFolderNode | undefined>(undefined)
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
 
   useEffect(() => {
     if (bookmarks.length) {
@@ -148,7 +153,18 @@ const Bookmarks = () => {
         open={isCreateAFolderDialogOpen}
         setOpen={setIsCreateAFolderDialogOpen}
       />
-
+      <EditBookmarkTab
+        open={isEditDialogOpen}
+        setOpen={setIsEditDialogOpen}
+        id={editFolder?.id}
+        title={editFolder?.title}
+      />
+      <DeleteDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        id={editFolder?.id}
+        label={editFolder?.title + " tab and it's contents"}
+      />     
       <div
         className={cn("mb-6 col-span-6 h-[70vh] overflow-scroll __vivid_hide-scrollbar", theme === "light" ? "dark" : "light")}
 
@@ -195,8 +211,8 @@ const Bookmarks = () => {
                   <ContextMenuContent className="w-fit min-w-40">
                     <ContextMenuItem
                       onClick={() => {
-                        setEditFolder(item)
-                        setIsEditDialogOpen(true)
+                        setEditFolder(item as BookmarkFolderNode)
+                        setTimeout(() => setIsEditDialogOpen(true), 100)
                       }}
                     >
                       Edit
@@ -211,7 +227,10 @@ const Bookmarks = () => {
                       </ContextMenuShortcut>
                     </ContextMenuItem>
                     <ContextMenuItem
-                      onClick={() => setIsDeleteDialogOpen(true)}
+                      onClick={() => {
+                        setEditFolder(item as BookmarkFolderNode)
+                        setIsDeleteDialogOpen(true)
+                      }}
                       className="text-destructive"
                     >
                       Delete

--- a/src/components/homepage/bookmarks/bookmarks.tsx
+++ b/src/components/homepage/bookmarks/bookmarks.tsx
@@ -194,7 +194,20 @@ const Bookmarks = () => {
               },
             ]
               .filter(Boolean))
-              .map((item) => (                
+              .map((item) => (      
+                (item.id === "home" || item.id === "history" || item.id === "top-sites") ? (
+                  <RootFolderButton
+                    key={item.id}
+                    disableDragging
+                    item={item}
+                    onClick={() => {
+                      setActiveRootFolder(item.id)
+                      setFolderStack([])
+                      chrome.storage.sync.set({ activeRootFolder: item.id })
+                    }}
+                    activeRootFolder={activeRootFolder}
+                  />
+                ) : (          
                 <ContextMenu key={item.id}>
                   <ContextMenuTrigger>
                     <RootFolderButton
@@ -240,7 +253,7 @@ const Bookmarks = () => {
                     </ContextMenuItem>
                   </ContextMenuContent>
                 </ContextMenu>
-              ))}
+              )))}
             <Button
               tabIndex={-1}
               size="sm"

--- a/src/components/homepage/bookmarks/bookmarks.tsx
+++ b/src/components/homepage/bookmarks/bookmarks.tsx
@@ -13,6 +13,9 @@ import {
   BookmarkPlusIcon,
   FolderPlusIcon,
   PlusIcon,
+  DeleteIcon,
+  EditIcon, 
+  MoveIcon
 } from "lucide-react"
 import { useEffect, useState } from "react"
 
@@ -24,6 +27,14 @@ import { DndContext, MouseSensor, TouchSensor, useSensor, useSensors, type DragE
 import RootFolderButton from "./root-folder-button"
 import useTopSites from "@/hooks/use-top-sites"
 import { useTheme } from "@/providers/theme-provider"
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuShortcut,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
 
 const Bookmarks = () => {
   const [activeRootFolder, setActiveRootFolder] = useState("home")
@@ -167,19 +178,49 @@ const Bookmarks = () => {
               },
             ]
               .filter(Boolean))
-              .map((item) => (
-                <RootFolderButton
-                  disableDragging={item.id === "home" || item.id === "history" || item.id === "top-sites"}
-                  item={item}
-                  onClick={() => {
-                    setActiveRootFolder(item.id)
-                    setFolderStack([])
-                    chrome.storage.sync.set({ activeRootFolder: item.id })
-                  }}
-                  activeRootFolder={activeRootFolder}
-                  key={item.id}
-                />
-
+              .map((item) => (                
+                <ContextMenu key={item.id}>
+                  <ContextMenuTrigger>
+                    <RootFolderButton
+                      disableDragging={item.id === "home" || item.id === "history" || item.id === "top-sites"}
+                      item={item}
+                      onClick={() => {
+                        setActiveRootFolder(item.id)
+                        setFolderStack([])
+                        chrome.storage.sync.set({ activeRootFolder: item.id })
+                      }}
+                      activeRootFolder={activeRootFolder}
+                    />
+                  </ContextMenuTrigger>
+                  <ContextMenuContent className="w-fit min-w-40">
+                    <ContextMenuItem
+                      onClick={() => {
+                        setEditFolder(item)
+                        setIsEditDialogOpen(true)
+                      }}
+                    >
+                      Edit
+                      <ContextMenuShortcut>
+                        <EditIcon className="size-4" />
+                      </ContextMenuShortcut>
+                    </ContextMenuItem>
+                    <ContextMenuItem>
+                      Move
+                      <ContextMenuShortcut>
+                        <MoveIcon className="size-4" />
+                      </ContextMenuShortcut>
+                    </ContextMenuItem>
+                    <ContextMenuItem
+                      onClick={() => setIsDeleteDialogOpen(true)}
+                      className="text-destructive"
+                    >
+                      Delete
+                      <ContextMenuShortcut>
+                        <DeleteIcon className="size-4" />
+                      </ContextMenuShortcut>
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                </ContextMenu>
               ))}
             <Button
               tabIndex={-1}

--- a/src/components/homepage/bookmarks/edit-bookmark-tab.tsx
+++ b/src/components/homepage/bookmarks/edit-bookmark-tab.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+type Props = {
+    open: boolean
+    setOpen: (open: boolean) => void
+    id: string
+    title: string
+}
+
+const EditBookmarkTab = ({ open, setOpen, id, title }: Props) => {
+  const [value, setValue] = useState(title || "")
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!value) return
+
+    if (id && title) {
+      chrome.bookmarks.update(id, { title: value }, () => {
+        setOpen(false)
+        window.dispatchEvent(new Event("bookmarks:update"))
+      })
+    } 
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-[425px]">
+        <form onSubmit={handleSubmit}>
+          <DialogClose />
+          <DialogHeader>
+            <DialogTitle>
+              Edit bookmark tab
+            </DialogTitle>
+            <DialogDescription>
+              Edit the tab you want to update.
+            </DialogDescription>
+          </DialogHeader>
+         <div className="grid gap-4 py-4 grid-cols-[1fr_50px] items-center">
+            <Input
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              id="name"
+              placeholder="Bookmarks"
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              size="sm"
+              className="min-w-32"
+              disabled={value.length === 0}
+              type="submit"
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default EditBookmarkTab


### PR DESCRIPTION
Addresses issue https://github.com/jrTilak/vivid-tab/issues/41 (FEAT: Edit tabs)

Updated bookmark tabs section so that they are now editable and deletable. Only custom tabs can be edited or deleted; the Home, History, and Top Sites tab cannot.