### PR TITLE
feat: add uninstall URL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 PLASMO_PUBLIC_PIXABAY_API_KEY=
 PLASMO_PUBLIC_WEATHER_API_KEY=
 PLASMO_PUBLIC_YOUTUBE_URL="https://www.youtube.com/watch?v=vqRNO5dKZdg"
+PLASMO_PUBLIC_UNINSTALL_URL="https://vividtab.jrtilak.dev/uninstall"

--- a/src/background.ts
+++ b/src/background.ts
@@ -83,3 +83,7 @@ chrome.alarms.onAlarm.addListener((alarm) => {
     wallpaper.fetchOnlineImages()
   }
 })
+
+if (process.env.PLASMO_PUBLIC_UNINSTALL_URL) {
+  chrome.runtime.setUninstallURL(process.env.PLASMO_PUBLIC_UNINSTALL_URL)
+}


### PR DESCRIPTION
Add support for setting a custom uninstall URL when the extension is removed. The URL is configured via PLASMO_PUBLIC_UNINSTALL_URL environment variable.